### PR TITLE
Adding NMS threshold and fixing minor bug when batching the patches

### DIFF
--- a/extract_kpts_dsc.py
+++ b/extract_kpts_dsc.py
@@ -46,7 +46,7 @@ def extract_features():
 
     # Read Key.Net model and extraction configuration
     conf = keynet_config[args.config_file]
-    keynet_model, desc_model = initialize_networks(conf)
+    keynet_model, desc_model = initialize_networks(conf, device)
 
     # read image and extract keypoints and descriptors
     f = open(args.list_images, "r")
@@ -65,3 +65,7 @@ def extract_features():
         np.save(result_path + '.dsc', desc)
 
     print('{} feature extraction finished.'.format(args.method_name))
+
+
+if __name__ == "__main__":
+    extract_features()

--- a/model/config_files/keynet_configs.py
+++ b/model/config_files/keynet_configs.py
@@ -19,5 +19,7 @@ keynet_config = {
             'up_levels': 1,
             'scale_factor_levels': np.sqrt(2),
             's_mult': 22,
+            'nms_thr' : 1.124,
+            'batch_size_dsc' : 1000
         },
 }

--- a/model/extraction_tools.py
+++ b/model/extraction_tools.py
@@ -57,6 +57,7 @@ def extract_ms_feats(keynet_model, desc_model, image, factor, s_mult, device,
     :param down_level: Indicates if images needs to go down one pyramid level
     :param up_level: Indicates if image is an upper scale level
     :param im_size: Original image size
+    :param batch_size_desc: Max number of patches per descriptor model call
     :return: It returns the local features for a specific image level
     '''
 


### PR DESCRIPTION
Main:
- Add parameter in config dictionary: NMS threshold #6 
- Solve error when batching the patches and the number of patches is divisible by 1000

Minor:
- Add parameter in config dictionary: number of patches when batching them (I believe this is useful when memory constraints exist)
- Add possibility to execute `extract_kpts_dsc.py` from command line
- Avoid redefinition of `device` when intializing the networks.